### PR TITLE
Update alias of struct tm to match the typedef tm* below

### DIFF
--- a/addons/libs/ffxi/time.lua
+++ b/addons/libs/ffxi/time.lua
@@ -37,7 +37,7 @@ ffi.cdef[[
         int32_t tm_wday;
         int32_t tm_yday;
         int32_t tm_isdst;
-    } tm_t;
+    } tm;
 
     typedef uint32_t    (__cdecl*   ntGameTimeDiff_f)(uint32_t);
     typedef uint32_t    (__stdcall* ntGameTimeGet_f)(void);


### PR DESCRIPTION
fix for import upon 'require('ffxi.time');'
original error message: 
`... \time.lua:48: declarration specifier expected near 'tm' at line 18`